### PR TITLE
fix: bug in hot reload

### DIFF
--- a/server.js
+++ b/server.js
@@ -8,6 +8,7 @@ new WebpackDevServer(webpack(config), {
   hot: true,
   inline: true,
   historyApiFallback: true,
+  headers: { 'Access-Control-Allow-Origin': '*' }
 }).listen(3000, '0.0.0.0', (err) => {
   if (err) {
     console.log(err);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Chrome developer console was accusing Access Control Allow Origin. I've updated 
the dev server configuration to allow request from any domain (django uses domain 
localhost:8000, and the dev server uses 0.0.0.0:3000).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The assets were not refreshing the site automatically because of Access Control Allow Origin error.

## Screenshots (if appropriate):

## Steps to reproduce (if appropriate):
* Follow the project setup instructions in README.md
* Run both django (python manage.py runserver) and webpack-dev-server (make build) with the default ports
* Update some static files
* Check Chrome developer console, to see the Access Control Allow Origin error

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
