### PR TITLE
Hotfix for bootstrap-loader incompatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,7 @@ django-admin startproject theprojectname --extension py,yml,json --name Procfile
 - [ ] `pip freeze > requirements.txt`
 - [ ] `npm update --save`
 - [ ] `npm update --save-dev`
-- [ ] Remove the `^` from `"bootstrap": "^4.0.0-alpha.6"` in the package.json file. While bootstrap is in alpha we have decided to lock the version to alpha6 to avoid breakage
-- [ ] Remove the `^` from `"bootstrap-loader": "^2.1.0"` in the package.json file. bootstrap-loader 2.2 breaks symversion by breaking support for 4.0.0-alpha.6. This step will be removed when we updated to bootstrap version.
+- [ ] Remove the `^` from `"bootstrap-loader": "^2.1.0"` in the package.json file. bootstrap-loader 2.2 breaks symversion by breaking support for 4.0.0-alpha.6. This step will be removed when we update to bootstrap beta version.
 - [ ] Check for outdated npm dependencies with `npm outdated` and update them
 - [ ] Change the first line of README to the name of the project
 - [ ] Add an email address to the `ADMINS` settings variable

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ django-admin startproject theprojectname --extension py,yml,json --name Procfile
 - [ ] `pip freeze > requirements.txt`
 - [ ] `npm update --save`
 - [ ] `npm update --save-dev`
-- [ ] Remove the `^` from `"bootstrap-loader": "^2.1.0"` in the package.json file. bootstrap-loader 2.2 breaks symversion by breaking support for 4.0.0-alpha.6. This step will be removed when we update to bootstrap beta version.
+- [ ] Remove the `^` from `"bootstrap-loader": "^2.1.0"` in the package.json file. bootstrap-loader 2.2 breaks semver by breaking support for 4.0.0-alpha.6. This step will be removed when we update to bootstrap beta version.
 - [ ] Check for outdated npm dependencies with `npm outdated` and update them
 - [ ] Change the first line of README to the name of the project
 - [ ] Add an email address to the `ADMINS` settings variable

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ django-admin startproject theprojectname --extension py,yml,json --name Procfile
 - [ ] `npm update --save`
 - [ ] `npm update --save-dev`
 - [ ] Remove the `^` from `"bootstrap": "^4.0.0-alpha.6"` in the package.json file. While bootstrap is in alpha we have decided to lock the version to alpha6 to avoid breakage
+- [ ] Remove the `^` from `"bootstrap-loader": "^2.1.0"` in the package.json file. bootstrap-loader 2.2 breaks symversion by breaking support for 4.0.0-alpha.6. This step will be removed when we updated to bootstrap version.
 - [ ] Check for outdated npm dependencies with `npm outdated` and update them
 - [ ] Change the first line of README to the name of the project
 - [ ] Add an email address to the `ADMINS` settings variable

--- a/circle.yml
+++ b/circle.yml
@@ -23,10 +23,10 @@ test:
         pwd: testproject
     - npm update --save-dev:
         pwd: testproject
-    - npm install:
-        pwd: testproject
     # hotfix for #133
-    - npm install bootstrap-loader@2.1.0:
+    - sed -i '' 's/"bootstrap-loader": "^2.1.0"/"bootstrap-loader": "2.1.0"/g' package.json:
+        pwd: testproject
+    - npm install:
         pwd: testproject
     # npm ls will error on dependencies errors
     - npm ls:

--- a/circle.yml
+++ b/circle.yml
@@ -24,8 +24,8 @@ test:
     - npm update --save-dev:
         pwd: testproject
     # hotfix for #133
-    - sed -i '' 's/"bootstrap-loader": "^2.1.0"/"bootstrap-loader": "2.1.0"/g' package.json:
-        pwd: testproject
+    - |
+      sed -i 's/"bootstrap-loader": "^2.1.0"/"bootstrap-loader": "2.1.0"/g' testproject/package.json
     - npm install:
         pwd: testproject
     # npm ls will error on dependencies errors

--- a/circle.yml
+++ b/circle.yml
@@ -25,6 +25,9 @@ test:
         pwd: testproject
     - npm install:
         pwd: testproject
+    # hotfix for #133
+    - npm install bootstrap-loader@2.1.0:
+        pwd: testproject
     # npm ls will error on dependencies errors
     - npm ls:
         pwd: testproject

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
     "bootstrap": "4.0.0-alpha.6",
-    "bootstrap-loader": "^2.1.0",
+    "bootstrap-loader": "2.1.0",
     "classnames": "^2.2.5",
     "css-loader": "^0.28.4",
     "expose-loader": "^0.7.3",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes #133 
bootstrap-loader does not respect symversion and a minor version fix ends up
breaking it for bootstrap alpha-6. We need to update to bootstrap beta before
allowing bootstrap-loader 2.2.

Permanent solution for this is to migrate to bootstrap beta.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
