### PR TITLE
Replace django.js-vinta with django-js-reverse

### DIFF
--- a/assets/js/components/HomePageReactTitle.js
+++ b/assets/js/components/HomePageReactTitle.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { Urls } from 'utils';
 
 const HomePageReactTitle = ({ title }) => {
-  const homeURL = Urls['home']();
+  const homeURL = Urls.home();
 
   return <h2>{title} (this is page {homeURL})</h2>;
 };

--- a/assets/js/components/HomePageReactTitle.js
+++ b/assets/js/components/HomePageReactTitle.js
@@ -1,8 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { Urls } from 'utils';
+
 const HomePageReactTitle = ({ title }) => {
-  const homeURL = window.Django.url('home');
+  const homeURL = Urls['home']();
 
   return <h2>{title} (this is page {homeURL})</h2>;
 };

--- a/assets/js/utils/index.js
+++ b/assets/js/utils/index.js
@@ -1,0 +1,5 @@
+import Urls from './urls';
+
+export {
+  Urls,
+};

--- a/assets/js/utils/index.js
+++ b/assets/js/utils/index.js
@@ -1,5 +1,5 @@
 import Urls from './urls';
 
 export {
-  Urls,
+  Urls, // eslint-disable-line import/prefer-default-export
 };

--- a/assets/js/utils/urls.js
+++ b/assets/js/utils/urls.js
@@ -1,0 +1,3 @@
+const Urls = window.Urls;
+
+export default Urls;

--- a/project_name/settings/base.py
+++ b/project_name/settings/base.py
@@ -34,7 +34,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
 
-    'djangojs',
+    'django_js_reverse',
     'webpack_loader',
 
     'common',

--- a/project_name/settings/local_base.py
+++ b/project_name/settings/local_base.py
@@ -64,3 +64,5 @@ LOGGING = {
         }
     }
 }
+
+JS_REVERSE_JS_MINIFY = False

--- a/project_name/settings/production.py
+++ b/project_name/settings/production.py
@@ -121,3 +121,5 @@ LOGGING = {
         },
     }
 }
+
+JS_REVERSE_EXCLUDE_NAMESPACES = ['admin']

--- a/project_name/urls.py
+++ b/project_name/urls.py
@@ -1,11 +1,12 @@
 from django.conf.urls import include, url
 from django.contrib import admin
 from django.views.generic import TemplateView
+import django_js_reverse.views
 
 
 urlpatterns = [
     url(r'^admin/', admin.site.urls),
-    url(r'^djangojs/', include('djangojs.urls')),
+    url(r'^jsreverse/$', django_js_reverse.views.urls_js, name='js_reverse'),
 
     url(r'^$', TemplateView.as_view(template_name='exampleapp/itworks.html'), name='home'),
 ]

--- a/project_name/urls.py
+++ b/project_name/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, url
+from django.conf.urls import include, url  # noqa
 from django.contrib import admin
 from django.views.generic import TemplateView
 import django_js_reverse.views

--- a/requirements-to-freeze.txt
+++ b/requirements-to-freeze.txt
@@ -5,7 +5,7 @@ Django
 celery[redis]
 django-model-utils
 django-webpack-loader
-django.js-vinta
+django-js-reverse
 python-decouple<=4.0
 psycopg2
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,5 +1,4 @@
 {% load render_bundle from webpack_loader %}
-{% load js %}
 
 <!doctype html>
 <html class="no-js" lang="en">
@@ -19,8 +18,8 @@
     {% block body %}{% endblock %}
 
     {% render_bundle 'main' 'js' 'JQUERY' %}
-    <!-- django.js -->
-    {% django_js jquery=false csrf=false %}
+    <!-- django-js-reverse -->
+    <script src="{% url 'js_reverse' %}" type="text/javascript"></script>
 
     <!-- Webpack rendered Javascript -->
     {% render_bundle 'main' 'js' %}

--- a/templates/exampleapp/itworks.html
+++ b/templates/exampleapp/itworks.html
@@ -1,5 +1,4 @@
 {% extends 'base.html' %}
-{% load js %}
 
 
 {% block body %}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Removed django.js-vinta and added django-js-reverse instead.

For the frontend I created a utils module called urls. This makes easy do change the global variable name in the future and also makes easy to create mocks for Urls.

## Motivation and Context
Issue #131 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
