### PR TITLE
STATIC_ROOT and MEDIA_ROOT should be absolute path

### DIFF
--- a/project_name/settings/local_base.py
+++ b/project_name/settings/local_base.py
@@ -14,10 +14,10 @@ DATABASES = {
     }
 }
 
-STATIC_ROOT = 'staticfiles'
+STATIC_ROOT = base_dir_join('staticfiles')
 STATIC_URL = '/static/'
 
-MEDIA_ROOT = 'mediafiles'
+MEDIA_ROOT = base_dir_join('mediafiles')
 MEDIA_URL = '/media/'
 
 DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'

--- a/project_name/settings/production.py
+++ b/project_name/settings/production.py
@@ -15,10 +15,10 @@ DATABASES['default']['ATOMIC_REQUESTS'] = True
 
 ALLOWED_HOSTS = config('ALLOWED_HOSTS', cast=Csv())
 
-STATIC_ROOT = 'staticfiles'
+STATIC_ROOT = base_dir_join('staticfiles')
 STATIC_URL = '/static/'
 
-MEDIA_ROOT = 'mediafiles'
+MEDIA_ROOT = base_dir_join('mediafiles')
 MEDIA_URL = '/media/'
 
 SERVER_EMAIL = 'foo@example.com'

--- a/project_name/settings/test.py
+++ b/project_name/settings/test.py
@@ -10,10 +10,10 @@ DATABASES = {
     }
 }
 
-STATIC_ROOT = 'staticfiles'
+STATIC_ROOT = base_dir_join('staticfiles')
 STATIC_URL = '/static/'
 
-MEDIA_ROOT = 'mediafiles'
+MEDIA_ROOT = base_dir_join('mediafiles')
 MEDIA_URL = '/media/'
 
 DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
STATIC_ROOT and MEDIA_ROOT should be absolute. [[1]](https://docs.djangoproject.com/en/1.11/ref/settings/#static-root) [[2]](https://docs.djangoproject.com/en/1.11/ref/settings/#media-root)

## Motivation and Context
Had some problems with relative STATIC_ROOT in production. Both heroku[[3]](https://devcenter.heroku.com/articles/django-assets) and whitenoise[[4]](http://whitenoise.evans.io/en/stable/django.html) docs suggest using absolute paths.

## Screenshots (if appropriate):

## Steps to reproduce (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
