### PR TITLE
Using Webpack file-loader for fonts

### DIFF
--- a/webpack.base.config.js
+++ b/webpack.base.config.js
@@ -59,8 +59,12 @@ module.exports = [{
         ],
       },
       {
-        test: /\.(woff(2)?|eot|ttf|svg)(\?v=\d+\.\d+\.\d+)?$/,
+        test: /\.(svg)(\?v=\d+\.\d+\.\d+)?$/,
         loader: 'url-loader?limit=100000',
+      },
+      {
+        test: /\.(woff(2)?|eot|ttf)(\?v=\d+\.\d+\.\d+)?$/,
+        loader: 'file-loader?name=fonts/[name].[ext]',
       },
       {
         test: /\.(jpg|png)?$/,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes #141.

## Description
<!--- Describe your changes in detail -->
Instead of using url-loader that loads the fonts as base64 data URIs and bloats the CSS, I changed the Webpack settings to use file-loader.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This is important to avoid embedding the font in the CSS. Large/bloated CSS files can affect the performance.

## Screenshots (if appropriate):

## Steps to reproduce (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
