### PR TITLE
Fix project variables in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ After completing ALL of the above, remove this `Project bootstrap` section from 
 - On project root, do the following:
 - Create a copy of ``{{project_name}}/settings/local.py.example``:  
   `cp {{project_name}}/settings/local.py.example {{project_name}}/settings/local.py` (remembering you should replace `{{project_name}}` with your project's name!).
-- Create a copy of ``.env.example``:  
+- Create a copy of ``.env.example``:  
   `cp .env.example .env`
 - Create the migrations for `users` app (do this, then remove this line from the README):  
   `python manage.py makemigrations`

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ After completing ALL of the above, remove this `Project bootstrap` section from 
   `cp .env.example .env`
 - Create the migrations for `users` app (do this, then remove this line from the README):  
   `python manage.py makemigrations`
-- If you get an "there's no module named django" error, install it through `pip install django<2` and try the step above again.
+- If you get an "there's no module named Django" error, install it through `pip install django<2` and try the step above again.
 - Run the migrations:  
   `python manage.py migrate`
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ django-admin startproject theprojectname --extension py,yml,json --name Procfile
 - [ ] `npm update --save-dev`
 - [ ] Check for outdated npm dependencies with `npm outdated` and update them.
 - [ ] Change the first line of README to the name of the project.
-- [ ] Add an email address to the `ADMINS` settings variable in `{{theprojectname}}/{{theprojectname}}/settings/base.py`
+- [ ] Add an email address to the `ADMINS` settings variable in `{{project_name}}/{{project_name}}/settings/base.py`
 - [ ] Change the `SERVER_EMAIL` to the email address used to send e-mails.
 
 After completing ALL of the above, remove this `Project bootstrap` section from the project README. Then follow `Running` below.
@@ -47,13 +47,13 @@ After completing ALL of the above, remove this `Project bootstrap` section from 
 ## Running
 ### Setup
 - On project root, do the following:
-- Create a copy of ``{{theprojectname}}/settings/local.py.example``:  
-  `cp {{theprojectname}}/settings/local.py.example {{theprojectname}}/settings/local.py` (remembering you should replace `{{theprojectname}}` with your project's name!).
+- Create a copy of ``{{project_name}}/settings/local.py.example``:  
+  `cp {{project_name}}/settings/local.py.example {{project_name}}/settings/local.py` (remembering you should replace `{{project_name}}` with your project's name!).
 - Create a copy of ``.env.example``:  
   `cp .env.example .env`
 - Create the migrations for `users` app (do this, then remove this line from the README):  
   `python manage.py makemigrations`
-- If you get an "there's no module named Django" error, install it through `pip install Django<2` and try the step above again.
+- If you get an "there's no module named django" error, install it through `pip install django<2` and try the step above again.
 - Run the migrations:  
   `python manage.py migrate`
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ After completing ALL of the above, remove this `Project bootstrap` section from 
   `cp {{project_name}}/settings/local.py.example {{project_name}}/settings/local.py` (remembering you should replace `{{project_name}}` with your project's name!).
 - Create a copy of ``.env.example``:  
   `cp .env.example .env`
-- Create the migrations for `users` app (do this, then remove this line from the README):  
+- Create the migrations for `users` app (do this, then remove this line from the README):  
   `python manage.py makemigrations`
 - If you get an "there's no module named django" error, install it through `pip install django<2` and try the step above again.
 - Run the migrations:  


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This pull request aims to fix the problem in which the README in cloned projects doesn't have the variables replaced where it should have.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Currently, when someone uses `django-admin` to create a project using this boilerplate, the variable `theprojectname` doesn't actually replace the existing others in README.

## Screenshots (if appropriate):
Example of a created project with current settings:
![image](https://user-images.githubusercontent.com/23136832/38584496-df618c4c-3cec-11e8-96c8-dd9b59470820.png)
i.e. If my project name was `vinta_project` it should be `vinta_project/settings/local.py.example`

## Steps to reproduce (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires documentation updates.
- [x] I have updated the documentation accordingly.
- [ ] My change requires dependencies updates.
- [ ] I have updated the dependencies accordingly.
