### PR TITLE
Support celery hotreload

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -16,7 +16,7 @@ fixmydjango = "*"
 isort = "*"
 model-mommy = "*"
 pre-commit = "*"
-prospector = {git = "https://github.com/vintasoftware/prospector.git", ref="0a63f2b", extras = ["with-vulture"]}
+prospector = {extras = ["with-vulture"]}
 pylint = "*"
 safety = "*"
 
@@ -36,6 +36,7 @@ django-log-request-id = "*"
 dj-database-url = "*"
 gunicorn = "*"
 whitenoise = "*"
+psutil = "*"
 ipython = "*"
 
 

--- a/Pipfile
+++ b/Pipfile
@@ -18,6 +18,8 @@ model-mommy = "*"
 pre-commit = "*"
 prospector = {extras = ["with-vulture"]}
 pylint = "*"
+pylint-django = "*"
+pylint-celery = "*"
 safety = "*"
 
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ After completing ALL of the above, remove this `Project bootstrap` section from 
 - `pipenv shell`
 - `python manage.py runserver`
 
+#### Celery
+- Open a command line window and go to the project's directory
+- `pipenv shell`
+- `python manage.py celery`
+
 ### Testing
 `make test`
 

--- a/common/management/commands/celery.py
+++ b/common/management/commands/celery.py
@@ -1,3 +1,4 @@
+# pylint: skip-file
 import shlex
 from subprocess import PIPE  # nosec
 

--- a/common/management/commands/celery.py
+++ b/common/management/commands/celery.py
@@ -1,0 +1,21 @@
+import shlex
+from subprocess import PIPE  # nosec
+
+from django.core.management.base import BaseCommand
+from django.utils import autoreload
+
+import psutil
+
+
+def restart_celery():
+    for proc in psutil.process_iter():
+        if proc.name() == 'celery':
+            proc.kill()
+    cmd = "celery worker -A {{project_name}} -l INFO"
+    psutil.Popen(shlex.split(cmd), stdout=PIPE)
+
+
+class Command(BaseCommand):
+    def handle(self, *args, **kwargs):
+        print('Starting celery worker with autoreload')
+        autoreload.main(restart_celery)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Having celery auto-reload when code base changes is really useful when developing. With this, we add support to it as a management command. Users can take advantage of it by using `python manage.py celery` instead of `celery -A {{project_name}} -l INFO`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
https://avilpage.com/2017/05/how-to-auto-reload-celery-workers-in-development.html

## Screenshots (if appropriate):
Not applicable;

## Steps to reproduce (if appropriate):
- `python manage.py celery`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires documentation updates.
- [x] I have updated the documentation accordingly.
- [x] My change requires dependencies updates.
- [x] I have updated the dependencies accordingly.
