### PR TITLE
Remove fixmydjango dependency to enable Django upgrade

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -12,7 +12,6 @@ coverage = "*"
 django-debug-toolbar = "*"
 django-debug-toolbar-request-history = "*"
 django-naomi = "*"
-fixmydjango = "*"
 isort = "*"
 model-mommy = "*"
 pre-commit = "*"
@@ -25,7 +24,7 @@ safety = "*"
 
 [packages]
 
-django = ">=1.11,<2"
+django = "*"
 celery = {extras = ["redis"]}
 django-model-utils = "*"
 django-webpack-loader = "*"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Django React Boilerplate
 
 ## About
-A [Django 1.11](https://www.djangoproject.com/) project boilerplate/template with lots of state of the art libraries and tools like:
+A [Django](https://www.djangoproject.com/) project boilerplate/template with lots of state of the art libraries and tools like:
 - [React](https://facebook.github.io/react/), for building interactive UIs
 - [django-js-reverse](https://github.com/ierror/django-js-reverse), for generating URLs on JS
 - [Bootstrap 4](https://v4-alpha.getbootstrap.com/), for responsive styling
@@ -52,7 +52,6 @@ After completing ALL of the above, remove this `Project bootstrap` section from 
   `cp .env.example .env`
 - Create the migrations for `users` app (do this, then remove this line from the README):  
   `python manage.py makemigrations`
-- If you get an "there's no module named Django" error, install it through `pip install django<2` and try the step above again.
 - Run the migrations:  
   `python manage.py migrate`
 

--- a/circle.yml
+++ b/circle.yml
@@ -13,7 +13,7 @@ machine:
 
 dependencies:
   post:
-    - pip install "django<2"
+    - pip install django
     - django-admin startproject testproject --extension py,yml,json --name Procfile,README.md --template=.
     - pip install requests pipenv --upgrade
 

--- a/project_name/settings/local_base.py
+++ b/project_name/settings/local_base.py
@@ -54,10 +54,6 @@ DEBUG_TOOLBAR_PANELS = [
     'debug_toolbar.panels.redirects.RedirectsPanel',
 ]
 
-# Fix My Django
-INSTALLED_APPS += ('fixmydjango',)
-FIX_MY_DJANGO_ADMIN_MODE = True
-
 # Logging
 LOGGING = {
     'version': 1,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Closes #167 by removing FixMyDjango dependency which held back the boilerplate from upgrading to Django 2. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Boilerplate upgrade to Django 2 was held back for a while, but up to now FixMyDjango doesn't support Django 2.

## Screenshots (if appropriate):
Not applicable

## Steps to reproduce (if appropriate):
Run project bootstrap instructions.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires documentation updates.
- [x] I have updated the documentation accordingly.
- [x] My change requires dependencies updates.
- [x] I have updated the dependencies accordingly.
