### PR TITLE
Fixes collectstatic environment variables

### DIFF
--- a/app.json
+++ b/app.json
@@ -9,7 +9,11 @@
       "description": "Django ALLOWED_HOSTS setting, e.g.: .appname.herokuapp.com"
     },
     "DISABLE_COLLECTSTATIC": {
-      "description": "Heroku setting to disable Django collectstatic (it is run by bin/post_compile)",
+      "description": "Disables Heroku collectstatic",
+      "value": "1"
+    },
+    "ENABLE_DJANGO_COLLECTSTATIC": {
+      "description": "Enables post-compile collectstatic (it is run by bin/post_compile)",
       "value": "1"
     },
     "AUTO_MIGRATE": {

--- a/bin/post_compile
+++ b/bin/post_compile
@@ -3,7 +3,7 @@ set -eo pipefail
 
 echo "-----> Post-compile hook"
 
-if [ -f bin/run_collectstatic ] && [ "$DISABLE_COLLECTSTATIC" == 0 ]; then
+if [ -f bin/run_collectstatic ] && [ -n "$ENABLE_DJANGO_COLLECTSTATIC" ] && [ "$ENABLE_DJANGO_COLLECTSTATIC" == 1 ]; then
     echo "-----> Running run_collectstatic"
     chmod +x bin/run_collectstatic
     bin/run_collectstatic


### PR DESCRIPTION
## Description
This change separates `COLLECT_STATIC` environment variables in two, one for the heroku and the other one for the post_compile script.

## Motivation and Context
This change is required for successful deployment in heroku, when using the `app.json` from the repository. With the actual configuration neither collect static is running when heroku builds the boilerplate app, which is not intended.

## Steps to reproduce (if appropriate):
- [ ] Create new project using the boilerplate
- [ ] Publish on Heroku using the `app.json` file
    - [ ] Without the fix, it shouldn't work
    - [ ] With the fix, it should work

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires documentation updates.
- [ ] I have updated the documentation accordingly.
- [ ] My change requires dependencies updates.
- [ ] I have updated the dependencies accordingly.
