### PR TITLE
Circleci directory fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,13 +124,17 @@ jobs:
     steps:
       - checkout
       - run:
-          command: mv proj_circle.yml .circleci/config.yml
+          command: mkdir -p circleci
+      - run:
+          command: mv proj_circle.yml circleci/config.yml
       - run:
           command: git checkout -b boilerplate-release
       - run:
-          command: git add .circleci/config.yml
+          command: git add circleci/config.yml
       - run:
           command: git rm proj_circle.yml
+      - run:
+          command: git rm -rf .circleci
       - run:
           command: git commit -m "Replacing circle.yml" --author "Vinta Software <contact@vinta.com.br>"
           environment:

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Also, includes a Heroku `app.json` and a working Django `production.py` settings
 This is a good starting point for modern Python/JavaScript web projects.
 
 ## Project bootstrap [![CircleCI](https://circleci.com/gh/vintasoftware/django-react-boilerplate.svg?style=svg)](https://circleci.com/gh/vintasoftware/django-react-boilerplate) [![Greenkeeper badge](https://badges.greenkeeper.io/vintasoftware/django-react-boilerplate.svg)](https://greenkeeper.io/)
+- [ ] Install Django with `pip install django`, to have the `django-admin` command available.
 - [ ] Open the command line and go to the directory you want to start your project in.
 - [ ] Start your project using:
 ```

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ django-admin startproject theprojectname --extension py,yml,json --name Procfile
 - [ ] Change the first line of README to the name of the project.
 - [ ] Add an email address to the `ADMINS` settings variable in `{{project_name}}/{{project_name}}/settings/base.py`
 - [ ] Change the `SERVER_EMAIL` to the email address used to send e-mails in `{{project_name}}/{{project_name}}/settings/production.py`
+- [ ] Rename the folder `circleci` to `.circleci`
 
 After completing ALL of the above, remove this `Project bootstrap` section from the project README. Then follow `Running` below.
 


### PR DESCRIPTION
This PR is needed because `django-admin startproject` does not import directories starting with `.`, which means the `.circleci` folder is not being restored correctly when the `django-admin startproject` command runs.