### PR TITLE
Fix path to manage.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ clean:
 	@find . -name "__pycache__" -delete
 
 test:
-	pipenv run python manage.py test $(ARG) --parallel --keepdb
+	pipenv run python backend/manage.py test $(ARG) --parallel --keepdb
 
 testreset:
-	pipenv run python manage.py test $(ARG) --parallel
+	pipenv run python backend/manage.py test $(ARG) --parallel


### PR DESCRIPTION
## Description
I got this error when I tried to run `make test`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
```shell
(django-react-boilerplate) ➜  django-react-boilerplate git:(mazulo/fix-makefile) ✗ make test
pipenv run python manage.py test  --parallel --keepdb
/home/mazulo/.virtualenvs/django-react-boilerplate/bin/python: can't open file 'manage.py': [Errno 2] No such file or directory
make: *** [Makefile:9: test] Error 2
```

## Steps to reproduce (if appropriate):
- Start a project with the boilerplate
- Try to run `make test`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires documentation updates.
- [ ] I have updated the documentation accordingly.
- [ ] My change requires dependencies updates.
- [ ] I have updated the dependencies accordingly.
