### PR TITLE
Fix celery command

### DIFF
--- a/backend/common/management/commands/celery.py
+++ b/backend/common/management/commands/celery.py
@@ -4,7 +4,7 @@ import shlex
 from subprocess import PIPE  # nosec
 
 from django.core.management.base import BaseCommand
-from django.utils import autoreload
+from django.utils.autoreload import run_with_reloader
 
 import psutil
 
@@ -29,4 +29,4 @@ def restart_celery():
 class Command(BaseCommand):
     def handle(self, *args, **kwargs):
         print('Starting celery worker with autoreload')
-        autoreload.main(restart_celery)
+        run_with_reloader(restart_celery)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Since we don't pin the Django version in `Pipfile` it will install the most recent stable Django version, which nowadays is 2.2.4.
```shell
(env) ➜  pip freeze | grep Django
Django==2.2.4
```
Django changed completely the way autoreload works from 2.2 on. For reference:
- https://code.djangoproject.com/ticket/27685
- https://github.com/django/django/pull/8819

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
After install all dependencies, if you try to run `python manage.py celery` you will get this error:
```shell
(env) ➜ python manage.py celery
Starting celery worker with autoreload
Traceback (most recent call last):
  File "backend/manage.py", line 27, in <module>
    execute_from_command_line(sys.argv)
  File "/home/mazulo/.virtualenvs/mangareader/lib/python3.7/site-packages/django/core/management/__init__.py", line 381, in execute_from_command_line
    utility.execute()
  File "/home/mazulo/.virtualenvs/mangareader/lib/python3.7/site-packages/django/core/management/__init__.py", line 375, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/home/mazulo/.virtualenvs/mangareader/lib/python3.7/site-packages/django/core/management/base.py", line 323, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/home/mazulo/.virtualenvs/mangareader/lib/python3.7/site-packages/django/core/management/base.py", line 364, in execute
    output = self.handle(*args, **options)
  File "/home/mazulo/Devel/web/python/djanga/backend/common/management/commands/celery.py", line 32, in handle
    autoreload.main(restart_celery)
AttributeError: module 'django.utils.autoreload' has no attribute 'main'
```

## Steps to reproduce (if appropriate):
- Start a new project using the boilerplate
- Install the dependencies
- Run `python manage.py celery`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires documentation updates.
- [ ] I have updated the documentation accordingly.
- [ ] My change requires dependencies updates.
- [ ] I have updated the dependencies accordingly.
