### PR TITLE
Adding dependencies for newest react-hot-loader versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "postcss-loader": "~2.0.6",
     "prop-types": "~15.5.10",
     "react": "~16.9.0",
+    "@types/react": "~16.9.0",
     "react-dom": "~16.9.0",
     "react-hot-loader": "~4.12.3",
     "redux": "~4.0.0",


### PR DESCRIPTION
Closes #402 

## Description
The newest version of _react-hot-loader_ changed the @types/react dependency to be a peer dependency and now it is needed to be manually added to the dependencies in the package.json file

## Motivation and Context
Fix the npm build

## Steps to reproduce:
- `npm install ` should not show any error or warning related to the peer dependencies from the react-hot-loader plugin

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires documentation updates.
- [ ] I have updated the documentation accordingly.
- [x] My change requires dependencies updates.
- [x] I have updated the dependencies accordingly.
