### PR TITLE
Stop pip-tools from installing Django 3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
       - run:
           command: sudo chown -R circleci:circleci /usr/local/lib/python3.7/site-packages
       - run:
-          command: pip install django<3
+          command: pip install django==2.*
       - run:
           command: django-admin startproject testproject --extension py,yml,json,example --name Procfile,README.md --template=.
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
       - run:
           command: sudo chown -R circleci:circleci /usr/local/lib/python3.7/site-packages
       - run:
-          command: pip install django
+          command: pip install django<3
       - run:
           command: django-admin startproject testproject --extension py,yml,json,example --name Procfile,README.md --template=.
       - run:

--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -1,10 +1,9 @@
 bandit
 coverage
-# Temporary fixed version. It will change when we update django version to > 3
-django-naomi==0.8
+django<3 # Fixed django version in order to avoid libs to install v3
+django-naomi
 isort
-# Temporary fixed version. It will be replace by model-bakery
-model-mommy==2.0.0
+model-mommy # It will be replace by model-bakery
 pre-commit
 prospector[with-vulture]
 safety

--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -1,8 +1,10 @@
 bandit
 coverage
-django-naomi
+# Temporary fixed version. It will change when we update django version to > 3
+django-naomi==0.8
 isort
-model-mommy
+# Temporary fixed version. It will be replace by model-bakery
+model-mommy==2.0.0
 pre-commit
 prospector[with-vulture]
 safety

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-django
+django<3
 celery[redis]
 django-model-utils
 django-webpack-loader


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Stops pip-tools from installing Django 3. This version is breaking django-model-utils (see screenshots) and could be breaking other libs.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We use libs that are not compatible with Django 3 yet.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/8878848/70051619-2e186700-15b0-11ea-8df4-42a3da9dfecb.png)

## Steps to reproduce (if appropriate):

- Run `pip-compile requirements.in > requirements.txt && pip-compile dev-requirements.in > dev-requirements.txt` inside a virtualenv
- Check if the django version in `requirements.txt` is below `3`
- Check if the django version in `dev-requirements.txt` is below `3`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires documentation updates.
- [ ] I have updated the documentation accordingly.
- [x] My change requires dependencies updates.
- [x] I have updated the dependencies accordingly.
