### PR TITLE
Fix Setup section on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,22 +46,24 @@ In the next steps, always remember to replace theprojectname with your project's
 After completing ALL of the above, remove this `Project bootstrap` section from the project README. Then follow `Running` below.
 
 ## Running
-### Setup (plain python)
+### Setup
 - Inside the `backend` folder, do the following:
-- Create a copy of ``{{project_name}}/settings/local.py.example``:
-  `cp {{project_name}}/settings/local.py.example {{project_name}}/settings/local.py` (remembering you should replace `{{project_name}}` with your project's name!).
+- Create a copy of ``{{project_name}}/settings/local.py.example``:  
+  `cp {{project_name}}/settings/local.py.example {{project_name}}/settings/local.py`
 - Create a copy of ``.env.example``:
   `cp .env.example .env`
-If you are using plain python:
-- Create the migrations for `users` app (do this, then remove this line from the README):
+
+#### If you are using plain python:
+- Create the migrations for `users` app: 
   `python manage.py makemigrations`
 - Run the migrations:
   `python manage.py migrate`
-If you are using docker:
-- Create the migrations for `users` app (do this, then remove this line from the README):
-  `docker-compose backend run python manage.py makemigrations`
+
+#### If you are using docker:
+- Create the migrations for `users` app:  
+  `docker-compose run --rm backend python manage.py makemigrations`
 - Run the migrations:
-  `docker-compose backend run python manage.py migrate`
+  `docker-compose run --rm backend python manage.py migrate`
 
 ### Tools
 - Setup [editorconfig](http://editorconfig.org/), [prospector](https://prospector.landscape.io/en/master/) and [ESLint](http://eslint.org/) in the text editor you will use to develop.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Fix docker-compose command ordering
* Some formatting changes
* Remove `(remembering you should replace {{project_name}} with your project's name!)` because when the person clones the project, this line is overwritten to something like `(remembering you should replace my_project with your project's name!)`, which can lead to confusion

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

* Fixes wrong docker-compose command
	```
	➜ docker-compose backend run python manage.py makemigrations
	No such command: backend
	```
* Fixes formatting (linebreaks aren't being considered on Setup section)
![image](https://user-images.githubusercontent.com/23136832/71527716-5fd4d300-28bb-11ea-872b-606258f95ae6.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires documentation updates.
- [x] I have updated the documentation accordingly.
- [ ] My change requires dependencies updates.
- [ ] I have updated the dependencies accordingly.
