### PR TITLE
Replace django-naomi with Mailhog

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,13 @@ To access the logs for each service run `docker-compose logs -f service_name` (e
 - `workon theprojectname` or `source theprojectname/bin/activate` depending on if you are using virtualenvwrapper or just virtualenv.
 - `python manage.py celery`
 
+#### Mailhog
+- For development, we use Mailhog to test our e-mail workflows, since it allows us to inspect the messages to validate they're correctly built
+  - Docker users already have it setup and running once they start the project
+  - For non-Docker users, please have a look [here](https://github.com/mailhog/MailHog#installation) for instructions on how to setup Mailhog on specific environments
+> The project expects Mailhog SMTP server to be running on port 1025, you may alter that by changing `EMAIL_PORT` on settings
+
+
 ### Testing
 `make test`
 
@@ -101,7 +108,7 @@ Will run django tests using `--keepdb` and `--parallel`. You may pass a path to 
 `make test someapp.tests.test_views`
 
 ### Adding new pypi libs
-Add the libname to either requirements.in or dev-requirents.in, then either upgrade the libs with `make upgrade` or manually compile it and then,  install.
+Add the libname to either `requirements.in` or `dev-requirements.in`, then either upgrade the libs with `make upgrade` or manually compile it and then,  install.
 `pip-compile requirements.in > requirements.txt` or `make upgrade`
 `pip install -r requirements.txt`
 
@@ -170,6 +177,6 @@ Check our [contributing guide](https://github.com/vintasoftware/django-react-boi
 ## Commercial Support
 This project, as other Vinta open-source projects, is used in products of Vinta clients. We are always looking for exciting work, so if you need any commercial support, feel free to get in touch: contact@vinta.com.br
 
-Copyright (c) 2020 Vinta Serviços e Soluções Tecnológicas Ltda.
+Copyright (c) 2021 Vinta Serviços e Soluções Tecnológicas Ltda.
 
 [MIT License](LICENSE.txt)

--- a/backend/project_name/settings/local_base.py
+++ b/backend/project_name/settings/local_base.py
@@ -27,9 +27,12 @@ CELERY_TASK_ALWAYS_EAGER = True
 CELERY_TASK_EAGER_PROPAGATES = True
 
 # Email
-INSTALLED_APPS += ("naomi",)
-EMAIL_BACKEND = "naomi.mail.backends.naomi.NaomiBackend"
-EMAIL_FILE_PATH = base_dir_join("tmp_email")
+EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+EMAIL_HOST = config("EMAIL_HOST")
+EMAIL_HOST_USER = config("EMAIL_HOST_USER")
+EMAIL_HOST_PASSWORD = config("EMAIL_HOST_PASSWORD")
+EMAIL_PORT = 587
+EMAIL_USE_TLS = True
 
 # Logging
 LOGGING = {

--- a/backend/project_name/settings/local_base.py
+++ b/backend/project_name/settings/local_base.py
@@ -26,13 +26,10 @@ AUTH_PASSWORD_VALIDATORS = []  # allow easy passwords only on local
 CELERY_TASK_ALWAYS_EAGER = True
 CELERY_TASK_EAGER_PROPAGATES = True
 
-# Email
+# Email settings for mailhog
 EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
-EMAIL_HOST = config("EMAIL_HOST")
-EMAIL_HOST_USER = config("EMAIL_HOST_USER")
-EMAIL_HOST_PASSWORD = config("EMAIL_HOST_PASSWORD")
-EMAIL_PORT = 587
-EMAIL_USE_TLS = True
+EMAIL_HOST = 'mailhog'
+EMAIL_PORT = 1025
 
 # Logging
 LOGGING = {

--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -2,7 +2,6 @@ bandit
 black
 coverage
 django<3 # Fixed django version in order to avoid libs to install v3
-django-naomi
 flake8==3.8.4
 isort
 model-bakery

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,8 +50,8 @@ services:
       - broker
       - result
 
-  mailhog:
+  mailhog: # service for faking a SMTP server
     image: mailhog/mailhog
     ports:
-      - "39004:1025"
-      - "39005:8025"
+      - '1025:1025' # smtp server
+      - '8025:8025' # web ui

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,3 +49,9 @@ services:
       - db
       - broker
       - result
+
+  mailhog:
+    image: mailhog/mailhog
+    ports:
+      - "39004:1025"
+      - "39005:8025"


### PR DESCRIPTION
Works only when developing using Docker
Closes #450 

## Steps to test
- [ ] Run the project
- [ ] Run the backend shell
- [ ] Run the following snippet
```python
from django.core.mail import send_mail
send_mail(
    'Test subject',
    'Here is the test message.',
    'from@example.com',
    ['to@example.com'],
    fail_silently=False,
)
```
- [ ] Go to 127.0.0:8025 and check if the email has been sent

## Steps to reproduce (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires documentation updates.
- [ ] I have updated the documentation accordingly.
- [ ] My change requires dependencies updates.
- [ ] I have updated the dependencies accordingly.
