### PR TITLE
Fix db.sqlite3 path on .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 *.pyc
-/db.sqlite3
+/backend/db.sqlite3
 .DS_Store
 .env
 */settings/local.py


### PR DESCRIPTION
## Description
Fixed the path to db.sqlite3 on .gitignore

## Motivation and Context
It prevents the db.sqlite3 file from being detected by git.

close #447 
