### PR TITLE
Fixing command to tests with docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,13 +8,13 @@ test:
 	python backend/manage.py test $(ARG) --parallel --keepdb
 
 dockertest:
-	docker-compose run backend python backend/manage.py test $(ARG) --parallel --keepdb
+	docker-compose run backend python manage.py test $(ARG) --parallel --keepdb
 
 testreset:
 	python backend/manage.py test $(ARG) --parallel
 
 dockertestreset:
-	docker-compose run backend python backend/manage.py test $(ARG) --parallel
+	docker-compose run backend python manage.py test $(ARG) --parallel
 
 backend_format:
 	black backend


### PR DESCRIPTION
## Description
As described on issue #444 the commands dockertest and dockertestreset don't work because the service built with docker is backend, with that said it isn't necessary to especify the path to backend on the commands described.

## Motivation and Context
Fix the command to run the test of the backend service on docker.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires documentation updates.
- [ ] I have updated the documentation accordingly.
- [ ] My change requires dependencies updates.
- [ ] I have updated the dependencies accordingly.
