### PR TITLE
Fix Makefile rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,16 +5,16 @@ clean:
 	@find . -name "__pycache__" -delete
 
 test:
-	python backend/manage.py test $(ARG) --parallel --keepdb
+	python backend/manage.py test backend/ $(ARG) --parallel --keepdb
 
 dockertest:
-	docker-compose run backend python backend/manage.py test $(ARG) --parallel --keepdb
+	docker-compose run backend python manage.py test $(ARG) --parallel --keepdb
 
 testreset:
-	python backend/manage.py test $(ARG) --parallel
+	python backend/manage.py test backend/ $(ARG) --parallel
 
 dockertestreset:
-	docker-compose run backend python backend/manage.py test $(ARG) --parallel
+	docker-compose run backend python manage.py test $(ARG) --parallel
 
 backend_format:
 	black backend
@@ -29,13 +29,17 @@ upgrade: ## update the *requirements.txt files with the latest packages satisfyi
 
 clean_examples:
 	# Remove the tables specific for the example app
-	python manage.py migrate exampleapp zero
+	python backend/manage.py migrate exampleapp zero
 	# Removing backend example app files
 	rm -rf ./backend/exampleapp
 	# Removing frontend example app files
 	rm -rf ./frontend/js/app/example-app
 	# Removing example templates files
 	rm -rf ./backend/templates/exampleapp
+	# Remove exampleapp from settings
+	sed -i '/exampleapp/d' ./backend/{{project_name}}/settings/base.py
+	# Remove exampleapp from urls
+	sed -i '/exampleapp/d' ./backend/{{project_name}}/urls.py
 
 compile_install_requirements:
 	@echo 'Installing pip-tools...'

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This is a good starting point for modern Python/JavaScript web projects.
 - [ ] Open the command line and go to the directory you want to start your project in.
 - [ ] Start your project using:
 ```
-django-admin startproject theprojectname --extension py,yml,json --name Procfile,Dockerfile,README.md,.env.example,.gitignore --template=https://github.com/vintasoftware/django-react-boilerplate/archive/boilerplate-release.zip
+django-admin startproject theprojectname --extension py,yml,json --name Procfile,Dockerfile,README.md,.env.example,.gitignore,Makefile --template=https://github.com/vintasoftware/django-react-boilerplate/archive/boilerplate-release.zip
 ```
 In the next steps, always remember to replace theprojectname with your project's name
 - [ ] Above: don't forget the `--extension` and `--name` params!


### PR DESCRIPTION
## Description
Fix the `test`, `testreset`, `dockertest` and `dockertestreset` rules. We also fix the `clean_examples` rule and add commands to remove `exempleapp` lines from the `urls.py` and `settings/base.py` files.
## Motivation and Context
`test` and `testreset` are broken because they are run from the parent directory of the `manage.py`. To fix we pass the Django project folder to it.
`dockertest` and `dockertestreset` are broken because the Dockerfile already sets the WORKDIR as the Django project folder.

## Steps to reproduce (if appropriate):
Create a new project following the instructions and run the rules.
`test` and `testreset` fails to find any  tests. After the fix -> runs 10 tests.
`dockertest` and `dockertestreset` fail because the path of the manage.py is wrong. After the fix -> run 10 tests.
`clean_examples` fail due to wrong manage.py path

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires documentation updates.
- [x] I have updated the documentation accordingly.
