### PR TITLE
chore(docker):working node version for node-sass

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts
+FROM node:14.5.0-alpine
 
 RUN mkdir /app/
 WORKDIR /app/


### PR DESCRIPTION
## Description
Latest version of node will not work with the current version on node-sass, making imposible to run docker compose. For more information, check [this](https://github.com/sass/node-sass#node-version-support-policy).

## Motivation and Context
Failed to build frontend image.

## Screenshots (if appropriate):
Console error when running make docker-setup.
![image](https://user-images.githubusercontent.com/3649569/141526988-9f1164d7-cd68-48af-9b74-25e933b5064c.png)


## Steps to reproduce (if appropriate):
Try `make docker-setup` with current docker image.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires documentation updates.
- [x] I have updated the documentation accordingly.
- [x] My change requires dependencies updates.
- [x] I have updated the dependencies accordingly.
