### PR TITLE
Fix project name string being hardcoded on base.py

### DIFF
--- a/backend/project_name/settings/base.py
+++ b/backend/project_name/settings/base.py
@@ -82,7 +82,7 @@ TEMPLATES = [
     },
 ]
 
-WSGI_APPLICATION = "theprojectname.wsgi.application"
+WSGI_APPLICATION = "{{project_name}}.wsgi.application"
 
 AUTH_PASSWORD_VALIDATORS = [
     {


### PR DESCRIPTION
Fix a missed case of the project name being hardcoded on base.py

## Description
The project name was hardcoded as `theprojectname` on the `WSGI_APPLICATION` variable, leading to errors when starting the project

## Steps to reproduce (if appropriate):
- Clone project
  - `django-admin startproject myotherprojectname --extension py,yml,json --name Procfile,Dockerfile,docker-compose.yml,README.md,.env.example,.gitignore,Makefile,render.yaml --template=https://github.com/vintasoftware/django-react-boilerplate/archive/boilerplate-release.zip`
- Follow read to install deps
- Try to run the backend with `poetry run python manage.py runserver`
- Get the error `ModuleNotFoundError: No module named 'theprojectname'` 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires documentation updates.
- [ ] I have updated the documentation accordingly.
- [ ] My change requires dependencies updates.
- [ ] I have updated the dependencies accordingly.
