### PR TITLE
Update scripts to use Docker Compose V2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,35 +12,35 @@ test_reset:
 	poetry run backend/manage.py test backend/ $(ARG) --parallel
 
 backend_format:
-	black backend 
+	black backend
 
 # Commands for Docker version
 docker_setup:
 	docker volume create {{project_name}}_dbdata
-	docker-compose build --no-cache backend
-	docker-compose run frontend npm install
+	docker compose build --no-cache backend
+	docker compose run frontend npm install
 
 docker_test:
-	docker-compose run backend python manage.py test $(ARG) --parallel --keepdb
+	docker compose run backend python manage.py test $(ARG) --parallel --keepdb
 
 docker_test_reset:
-	docker-compose run backend python manage.py test $(ARG) --parallel
+	docker compose run backend python manage.py test $(ARG) --parallel
 
 docker_up:
-	docker-compose up -d
+	docker compose up -d
 
 docker_update_dependencies:
-	docker-compose down
-	docker-compose up -d --build
+	docker compose down
+	docker compose up -d --build
 
 docker_down:
-	docker-compose down
+	docker compose down
 
 docker_logs:
-	docker-compose logs -f $(ARG)
+	docker compose logs -f $(ARG)
 
 docker_makemigrations:
-	docker-compose run --rm backend python manage.py makemigrations
+	docker compose run --rm backend python manage.py makemigrations
 
 docker_migrate:
-	docker-compose run --rm backend python manage.py migrate
+	docker compose run --rm backend python manage.py migrate


### PR DESCRIPTION
## Description

Update scripts to use Compose V2 by replacing the hyphen (`-`) with a space, using `docker compose` instead of `docker-compose`. Docs: https://docs.docker.com/compose/migrate/

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Steps to reproduce (if appropriate):

- Run the modified make commands and make sure they are working properly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires documentation updates.
- [ ] I have updated the documentation accordingly.
- [ ] My change requires dependencies updates.
- [ ] I have updated the dependencies accordingly.
