### PR TITLE
add clean: true to productionOutput in webpack.config.js

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,6 +16,7 @@ module.exports = (env, argv) => {
     path: path.resolve("./frontend/webpack_bundles/"),
     publicPath: "auto",
     filename: "[name]-[chunkhash].js",
+    clean: true,
   };
 
   return {


### PR DESCRIPTION
Adds clean: true to productionOutput in webpack.config.js, which clears the webpack_bundles folder before each build.

Fixes #680 
