### PR TITLE
Use cached_db sessions by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,9 @@ docker_migrate:
 docker_backend_shell:
 	docker compose run --rm backend bash
 
+docker_backend_manage:
+	docker compose run --rm backend python manage.py $(ARG)
+
 docker_backend_update_schema:
 	docker compose run --rm backend python manage.py spectacular --color --file schema.yml
 
@@ -57,3 +60,6 @@ docker_frontend_shell:
 
 docker_frontend_update_api:
 	docker compose run --rm frontend pnpm run openapi-ts
+
+docker_redis_clear:
+	docker compose exec result redis-cli FLUSHDB

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -27,4 +27,4 @@ WORKDIR /home/user/app/backend
 COPY backend/ /home/user/app/backend
 
 USER user
-CMD gunicorn new_styling.wsgi --log-file - --access-logfile - --access-logformat '%(t)s %(h)s "%(r)s" %(s)s %(b)s %(L)ss' -b 0.0.0.0:8000 --reload
+CMD gunicorn {{project_name}}.wsgi --log-file - --access-logfile - --access-logformat '%(t)s %(h)s "%(r)s" %(s)s %(b)s %(L)ss' -b 0.0.0.0:8000 --reload

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -27,4 +27,4 @@ WORKDIR /home/user/app/backend
 COPY backend/ /home/user/app/backend
 
 USER user
-CMD gunicorn {{project_name}}.wsgi --log-file - -b 0.0.0.0:8000 --reload
+CMD gunicorn new_styling.wsgi --log-file - --access-logfile - --access-logformat '%(t)s %(h)s "%(r)s" %(s)s %(b)s %(L)ss' -b 0.0.0.0:8000 --reload

--- a/backend/project_name/settings/base.py
+++ b/backend/project_name/settings/base.py
@@ -124,12 +124,20 @@ SPECTACULAR_SETTINGS = {
     "SERVE_INCLUDE_SCHEMA": False,
 }
 
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.redis.RedisCache",
+        "LOCATION": config("REDIS_URL", default="redis://result:6379/1"),
+    }
+}
+
+SESSION_ENGINE = "django.contrib.sessions.backends.cached_db"
+
 LANGUAGE_CODE = "en-us"
 
 TIME_ZONE = "UTC"
 
 USE_I18N = True
-
 
 USE_TZ = True
 

--- a/backend/project_name/settings/test.py
+++ b/backend/project_name/settings/test.py
@@ -26,3 +26,11 @@ PASSWORD_HASHERS = [
 # Celery
 CELERY_TASK_ALWAYS_EAGER = True
 CELERY_TASK_EAGER_PROPAGATES = True
+
+# Use in-memory cache for tests
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "test-cache",
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR improves the backend session setup by configuring Django to use Redis as the default cache and cached_db
as the session engine, bringing the application closer to its intended runtime behavior. It also improves
development visibility by enabling more detailed Gunicorn access logs, making it easier to inspect requests and
debug backend behavior locally. Since the new session setup introduces a cache dependency, the test configuration
was updated to use an in-memory cache to keep tests isolated and independent from Redis.

## Motivation and Context

The changes in this PR are grouped because they all support the same backend infrastructure improvement:

 1. Session/cache setup: configure Redis as the default Django cache and switch sessions to cached_db.
 2. Developer visibility: improve Gunicorn access logging in development to make request behavior easier to
inspect.
 3. Test isolation: override the cache backend in tests to use in-memory storage instead of Redis.

Overall, this brings development and runtime behavior closer together while keeping the test environment
lightweight and deterministic.

## Screenshots (if appropriate):

N/A

## Steps to reproduce (if appropriate):

- [ ] Create a new project using this branch as the template:

```bash
django-admin startproject new_styling --extension py,json,yml,yaml,toml --name Dockerfile,README.md,.env.example,.gitignore,Makefile,.npmrc --template=https://github.com/vintasoftware/django-react-boilerplate/archive/refs/heads/560-use-cache-db-sessions-by-default.zip
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires documentation updates.
- [ ] I have updated the documentation accordingly.
- [ ] My change requires dependencies updates.
- [ ] I have updated the dependencies accordingly.

Closes #560 
