### PR TITLE
Fix user creation and patch/put assertions in tests

### DIFF
--- a/backend/users/tests/test_views.py
+++ b/backend/users/tests/test_views.py
@@ -24,7 +24,7 @@ class UserViewSetTest(TestCaseUtils, APITestCase):
             "password": "12345678",
         }
 
-        response = self.auth_client.post(reverse("user-list"), data=data)
+        response = self.auth_client.post(reverse("user-registration"), data=data)
 
         self.assertResponse201(response)
         user = User.objects.get(id=response.data["id"])
@@ -52,7 +52,7 @@ class UserViewSetTest(TestCaseUtils, APITestCase):
 
         self.assertResponse200(response)
         user.refresh_from_db()
-        self.assertEqual(user.email, data["email"])
+        self.assertNotEqual(user.email, data["email"])
 
     def test_patch_update_user(self):
         user = baker.make(User, email="testuser@test.com", _fill_optional=True)
@@ -66,7 +66,7 @@ class UserViewSetTest(TestCaseUtils, APITestCase):
 
         self.assertResponse200(response)
         user.refresh_from_db()
-        self.assertEqual(user.email, data["email"])
+        self.assertNotEqual(user.email, data["email"])
 
     def test_delete_user(self):
         user = baker.make(User, _fill_optional=True)


### PR DESCRIPTION
user CREATION test should point to a user creation/registration endpoint, not list. user PUT and PATCH tests should result in the emails NOT matching since they have been updated.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Steps to reproduce (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires documentation updates.
- [ ] I have updated the documentation accordingly.
- [ ] My change requires dependencies updates.
- [ ] I have updated the dependencies accordingly.
